### PR TITLE
Add parenthesis matching for readline

### DIFF
--- a/readline-doc/readline/readline.scrbl
+++ b/readline-doc/readline/readline.scrbl
@@ -246,7 +246,7 @@ to the @racket[proc].}
 Sets the cursor to the start of a new line.}
 
 
-@defproc[(readline-redisplay) void?]{
+@defproc[(readline-redisplay [#:force? force? any/c #t]) void?]{
 
 Forces a redisplay of the @|readline| prompt and current user input.
 
@@ -265,15 +265,50 @@ following:
     output-thunk
     (lambda ()
       (readline-redisplay)
-      (end-atomic))))]}
+      (end-atomic))))]
+
+When @racket[force?] is @racket[#f], updates the display to show the new
+state of the readline buffer but does not force it. This is equivalent to
+using the @tt{rl_redisplay} function from @|readline|.}
 
 
-@defparam[match-paren-timeout timeout (or/c #f (>=/c 0))
-          #:value 500]{
+@defproc[(readline-insert-text [text string?]) void?]{
 
-Sets the length of time in milliseconds that the cursor should blink
-when matching parentheses are typed in the line editor. When @racket[timeout]
-is @racket[#f], parenthesis matching is disabled.}
+Inserts the given string at the current cursor position in the @|readline|
+buffer.}
+
+
+@defparam[readline-point point exact-integer?]{
+
+Contains the current cursor position in the @|readline| buffer. Setting
+this parameter will change the actual position in the buffer.}
+
+
+@defproc[(readline-buffer) bytes?]{
+
+Contains the current state of the @|readline| buffer. Mutating the
+resulting bytestring will mutate the actual contents of the buffer,
+which will be reflected on the screen after a redisplay.
+
+Note that the buffer will only contain the contents up to the current
+length of the buffer. If the buffer length grows due to a text insertion,
+the new text will only be visible in a newly allocated bytestring from
+another call to this function.}
+
+
+@defproc[(readline-bind-key [char-code byte?]
+                            [handler (-> exact-integer? byte? void?)])
+          void?]{
+
+Binds the key corresponding to @racket[char-code] to an action defined by
+the @racket[handler] function. The two arguments to the handler are a
+command-dependent numeric argument and the character code of the key that
+was pressed.}
+
+
+@defparam[readline-startup-hook hook (-> void?)]{
+
+Contains a procedure that is called when @|readline| is initialized.}
 
 
 @section[#:tag "readline-license"]{License Issues}

--- a/readline-doc/readline/readline.scrbl
+++ b/readline-doc/readline/readline.scrbl
@@ -268,6 +268,14 @@ following:
       (end-atomic))))]}
 
 
+@defparam[match-paren-timeout timeout (or/c #f (>=/c 0))
+          #:value 500]{
+
+Sets the length of time in milliseconds that the cursor should blink
+when matching parentheses are typed in the line editor. When @racket[timeout]
+is @racket[#f], parenthesis matching is disabled.}
+
+
 @section[#:tag "readline-license"]{License Issues}
 
 GNU's @|readline| library is covered by the GPL, and that applies to

--- a/readline-lib/info.rkt
+++ b/readline-lib/info.rkt
@@ -1,7 +1,7 @@
 #lang info
 
 (define collection 'multi)
-(define deps '("base" "syntax-color-lib"))
+(define deps '("base"))
 
 (define pkg-desc "implementation (no documentation) part of \"readline\"")
 

--- a/readline-lib/info.rkt
+++ b/readline-lib/info.rkt
@@ -1,7 +1,7 @@
 #lang info
 
 (define collection 'multi)
-(define deps '("base"))
+(define deps '("base" "syntax-color-lib"))
 
 (define pkg-desc "implementation (no documentation) part of \"readline\"")
 

--- a/readline-lib/readline/match-parens.rkt
+++ b/readline-lib/readline/match-parens.rkt
@@ -1,0 +1,94 @@
+#lang racket/base
+
+;; support for bouncing/matching parens, with some inspiration from
+;; Guile's readline support
+
+(require "rktrl.rkt")
+
+(provide match-paren-timeout
+         install-match-paren-bindings!)
+;; avoid a hard dependency on the lexer
+(define lexer (dynamic-require 'syntax-color/racket-lexer 'racket-lexer
+                               (λ () #f)))
+
+;; timeout in milliseconds
+(define match-paren-timeout (make-parameter 500))
+
+;; int? int? -> void?
+;; Matches parentheses in the buffer and flashes the current pair when a
+;; new closing paren is typed. Ignores the first argument and the second
+;; argument should be the key passed from readline.
+(define (match-parens _ char)
+  (define cur-point (readline-point))
+  (readline-insert-text (make-string 1 (integer->char char)))
+  (when (match-paren-timeout)
+    (define new-point (find-match cur-point char))
+    (when new-point
+      (readline-point new-point)
+      (readline-redisplay #:force? #f)
+      (sleep (/ (match-paren-timeout) 1000))
+      ;; move to after the newly inserted character
+      (readline-point (add1 cur-point)))))
+
+;; exact-integer? byte? -> (or/c #f exact-integer?)
+;; Find the index in the readline buffer of the matching paren or
+;; #f if it does not exist.
+(define (find-match point char)
+  (define input (buffer->input-port point))
+  (define target-sym (byte->symbol char))
+  (let loop ([stack null] [last-match #f])
+    (define-values (match type paren-kind start end)
+      (lexer input))
+    (cond [(eof-object? match)
+           ;; check that the match, if it exists, is actually a match
+           ;; for the new inserted character (by position in the buffer)
+           (and last-match
+                (eq? target-sym (car (cadr last-match)))
+                ;; the lexer is 1-indexed, so subtract for 0-index
+                (= point (sub1 (cadr (cadr last-match))))
+                (sub1 (cadr (car last-match))))]
+          [(eq? type 'parenthesis)
+           ;; matching pairs are removed from the stack, but remembered
+           ;; for the end in case it's the new character and its match
+           (if (and (not (null? stack))
+                    (matching-paren? (caar stack) paren-kind))
+               (loop (cdr stack)
+                     (list (car stack) `(,paren-kind ,start)))
+               (loop (cons `(,paren-kind ,start) stack)
+                     last-match))]
+          [else (loop stack last-match)])))
+
+;; symbol? symbol? -> boolean?
+;; Test if two parentheses are a matching pair
+(define (matching-paren? p1 p2)
+  (or (and (eq? p1 '|(|) (eq? p2 '|)|))
+      (and (eq? p1 '|[|) (eq? p2 '|]|))
+      (and (eq? p1 '|{|) (eq? p2 '|}|))))
+
+;; byte? -> symbol?
+;; Convert a character code for a parenthesis to a symbol
+(define (byte->symbol byte)
+  (string->symbol (make-string 1 (integer->char byte))))
+
+;; exact-integer? -> input-port
+;; Turn the readline buffer contents into an input port from
+;; the start up to the specified point
+(define (buffer->input-port point)
+  (define buffer-string
+    (list->string
+     (for/list ([char-code (in-bytes (readline-buffer) 0 (add1 point))])
+       (integer->char char-code))))
+  (open-input-string buffer-string))
+
+;; bind a startup hook to install the paren matching in the right keymap
+(define close-paren-code   (char->integer #\)))
+(define close-bracket-code (char->integer #\]))
+(define close-brace-code   (char->integer #\}))
+
+(define (install-match-paren-bindings!)
+  (when lexer
+    (readline-startup-hook
+     (lambda ()
+         (readline-bind-key close-paren-code   match-parens)
+         (readline-bind-key close-bracket-code match-parens)
+         (readline-bind-key close-brace-code   match-parens)))))

--- a/readline-lib/readline/rep-start.rkt
+++ b/readline-lib/readline/rep-start.rkt
@@ -3,8 +3,12 @@
 
 #lang racket/base
 
-(require "pread.rkt")
+(require "pread.rkt"
+         "match-parens.rkt")
 
 ;; Change the input port and readline-prompt hook
 (current-input-port readline-input)
 (current-prompt-read read-cmdline-syntax)
+
+;; Add parenthesis matching
+(install-match-paren-bindings!)

--- a/readline-lib/readline/rktrl.rkt
+++ b/readline-lib/readline/rktrl.rkt
@@ -1,13 +1,15 @@
 #lang racket/base
 
-(require ffi/unsafe (only-in '#%foreign ffi-obj)
-         syntax-color/racket-lexer)
+(require ffi/unsafe (only-in '#%foreign ffi-obj))
 (provide readline readline-bytes
          add-history add-history-bytes
          history-length history-get history-delete
          set-completion-function!
          readline-newline readline-redisplay
-         match-paren-timeout)
+         readline-buffer readline-point
+         readline-insert-text
+         readline-bind-key
+         readline-startup-hook)
 
 ;; libncurses and/or libtermcap needed on some platforms
 (void (ffi-lib "libcurses" #:fail (lambda () #f)))
@@ -140,103 +142,30 @@
                  (get-ffi-obj "rl_newline" libreadline (_fun -> _void)))))
 
 ;; force redisplay of prompt and current user input
-(define readline-redisplay
+(define rl-forced-update-display
   (get-ffi-obj "rl_forced_update_display" libreadline (_fun -> _void)))
-
-;; support for bouncing/matching parens, with some inspiration from
-;; Guile's readline support
-
-;; timeout in milliseconds
-(define match-paren-timeout (make-parameter 500))
-
-;; these internal bindings aren't for export
-(define rl-buffer (ffi-obj #"rl_line_buffer" libreadline))
-(define rl-point  (ffi-obj #"rl_point" libreadline))
-
 (define rl-redisplay (get-ffi-obj #"rl_redisplay" libreadline (_fun -> _void)))
-(define rl-bind-key  (get-ffi-obj #"rl_bind_key" libreadline
-                                  (_fun _int (_fun _int _int -> _void)
-                                        -> _void)))
-(define rl-insert    (get-ffi-obj #"rl_insert" libreadline
-                                  (_fun _int _int -> _void)))
 
-;; int? int? -> void?
-;; Matches parentheses in the buffer and flashes the current pair when a
-;; new closing paren is typed. Ignores the first argument and the second
-;; argument should be the key passed from readline.
-(define (match-parens _ char)
-  (define cur-point (ptr-ref rl-point _int))
-  (rl-insert 1 char)
-  (when (match-paren-timeout)
-    (define new-point (find-match cur-point char))
-    (when new-point
-      (ptr-set! rl-point _int new-point)
-      (rl-redisplay)
-      (sleep (/ (match-paren-timeout) 1000))
-      ;; move to after the newly inserted character
-      (ptr-set! rl-point _int (add1 cur-point)))))
+(define (readline-redisplay #:force? [force? #t])
+  (if force?
+      (rl-forced-update-display)
+      (rl-redisplay)))
 
-;; exact-integer? byte? -> (or/c #f exact-integer?)
-;; Find the index in the readline buffer of the matching paren or
-;; #f if it does not exist.
-(define (find-match point char)
-  (define input (buffer->input-port point))
-  (define target-sym (byte->symbol char))
-  (let loop ([stack null] [last-match #f])
-    (define-values (match type paren-kind start end)
-      (racket-lexer input))
-    (cond [(eof-object? match)
-           ;; check that the match, if it exists, is actually a match
-           ;; for the new inserted character (by position in the buffer)
-           (and last-match
-                (eq? target-sym (car (cadr last-match)))
-                ;; the lexer is 1-indexed, so subtract for 0-index
-                (= point (sub1 (cadr (cadr last-match))))
-                (sub1 (cadr (car last-match))))]
-          [(eq? type 'parenthesis)
-           ;; matching pairs are removed from the stack, but remembered
-           ;; for the end in case it's the new character and its match
-           (if (and (not (null? stack))
-                    (matching-paren? (caar stack) paren-kind))
-               (loop (cdr stack)
-                     (list (car stack) `(,paren-kind ,start)))
-               (loop (cons `(,paren-kind ,start) stack)
-                     last-match))]
-          [else (loop stack last-match)])))
+;; insert text into the buffer
+(define readline-insert-text
+  (get-ffi-obj #"rl_insert_text" libreadline (_fun _string -> _void)))
 
-;; symbol? symbol? -> boolean?
-;; Test if two parentheses are a matching pair
-(define (matching-paren? p1 p2)
-  (or (and (eq? p1 '|(|) (eq? p2 '|)|))
-      (and (eq? p1 '|[|) (eq? p2 '|]|))
-      (and (eq? p1 '|{|) (eq? p2 '|}|))))
+;; buffer-related globals
+(define readline-point  (make-c-parameter #"rl_point" libreadline _int))
+(define (readline-buffer)
+  (get-ffi-obj #"rl_line_buffer" libreadline _bytes))
 
-;; byte? -> symbol?
-;; Convert a character code for a parenthesis to a symbol
-(define (byte->symbol byte)
-  (string->symbol (make-string 1 (integer->char byte))))
+;; bind a key to a user-provided operation
+(define readline-bind-key
+  (get-ffi-obj #"rl_bind_key" libreadline
+               (_fun _int (_fun _int _byte -> _void)
+                     -> _void)))
 
-;; exact-integer? -> input-port
-;; Turn the readline buffer contents into an input port from
-;; the start up to the specified point
-(define (buffer->input-port point)
-  (define buffer-string
-    (list->string (for/list ([idx (in-range (add1 point))])
-                    (integer->char (buffer-ref idx)))))
-  (open-input-string buffer-string))
-
-;; exact-integer? -> byte?
-;; Dereference a byte in the readline buffer
-(define (buffer-ref idx)
-  (ptr-ref (ptr-ref rl-buffer _pointer) _byte idx))
-
-;; bind a startup hook to install the paren matching in the right keymap
-(define close-paren-code   (char->integer #\)))
-(define close-bracket-code (char->integer #\]))
-(define close-brace-code   (char->integer #\}))
-
-(set-ffi-obj! "rl_startup_hook" libreadline (_fun -> _void)
-              (lambda ()
-                (rl-bind-key close-paren-code   match-parens)
-                (rl-bind-key close-bracket-code match-parens)
-                (rl-bind-key close-brace-code   match-parens)))
+;; a function to call on startup for readline
+(define readline-startup-hook
+  (make-c-parameter #"rl_startup_hook" libreadline (_fun -> _void)))

--- a/readline-lib/readline/rktrl.rkt
+++ b/readline-lib/readline/rktrl.rkt
@@ -203,6 +203,9 @@
       ;; move to after the newly inserted character
       (ptr-set! rl-point _int (add1 cur-point)))))
 
-(rl-bind-key close-paren-code   match-parens)
-(rl-bind-key close-bracket-code match-parens)
-(rl-bind-key close-brace-code   match-parens)
+;; bind a startup hook to install the paren matching in the right keymap
+(set-ffi-obj! "rl_startup_hook" libreadline (_fun -> _void)
+              (lambda ()
+                (rl-bind-key close-paren-code   match-parens)
+                (rl-bind-key close-bracket-code match-parens)
+                (rl-bind-key close-brace-code   match-parens)))


### PR DESCRIPTION
This PR adds the ability to match and blink parentheses typed at the REPL with readline enabled. The feature is inspired by Guile's readline support and is implemented in a similar way, though in Racket rather than C.

This only works when the installed libreadline is actually readline and not libedit. In other words, this will not work on Mac systems where readline has not been explicitly installed. (libedit's readline compatibility layer is just not good enough) If we want libedit support, I think the best thing to do is to build a separate libedit FFI binding.

Also, I considered if this would be a better fit in `readline/pread` instead, but since it requires low-level readline functionality (such as directly modifying the readline cursor position), I thought it best to put it with the rest of the low level functions.

@mflatt @elibarzilay I think you two are the best people to review this. Does it look reasonable?

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/racket/readline/2)

<!-- Reviewable:end -->
