### PR TITLE
Add symlinked version for Fedora 25

### DIFF
--- a/readline-lib/readline/rktrl.rkt
+++ b/readline-lib/readline/rktrl.rkt
@@ -40,7 +40,7 @@
      (when lib
        (set! old-libedit #t))
      lib)
-   (ffi-lib "libedit" '("3" "2" "0.0.43" "0.0.53" ""))))
+   (ffi-lib "libedit" '("3" "2" "0.0.43" "0.0.53" "0" ""))))
 
 (define make-byte-string ; helper for the two types below
   (get-ffi-obj "scheme_make_byte_string" #f (_fun _pointer -> _scheme)))


### PR DESCRIPTION
In Fedora 25, `readline` (and thus `xrepl`) break since they can't find the libedit library.

`libedit.so.0` is a symlink to `libedit.so.0.0.54`, the version installed in Fedora 25. Pointing to the symlink should catch more cases by default. This should in theory also work for older versions of Fedora (for instance, the ones pointing to "0.0.43" and "0.0.53"), but I haven't actually tested that yet.