### PR TITLE
Fix PLT_READLINE_LIB handling

### DIFF
--- a/readline-lib/readline/rktrl.rkt
+++ b/readline-lib/readline/rktrl.rkt
@@ -30,7 +30,7 @@
   (or
    (let ([readline-path (getenv "PLT_READLINE_LIB")])
      (and readline-path
-          (ffi-lib readline-path (lambda () #f))))
+          (ffi-lib readline-path #:fail (lambda () #f))))
    (find-libreadline (find-user-share-dir))
    (find-libreadline (find-share-dir))
    ;; Old versions of libedit have a 1 indexed history rather than a 0 indexed history.


### PR DESCRIPTION
Without the #:fail keyword, this code fails as:

; string-length: contract violation
;   expected: string?
;   given: #<procedure:temp2>