### PR TITLE
add set-completion-append-character!

### DIFF
--- a/readline-doc/readline/readline.scrbl
+++ b/readline-doc/readline/readline.scrbl
@@ -268,6 +268,16 @@ Sets @|readline|'s @tt{rl_completion_entry_function} to
 from @racketmodname[ffi/unsafe], determines the type of value supplied
 to the @racket[proc].}
 
+@defproc[(set-completion-append-character! [c char?])
+         void?]{
+Sets @|readline|'s @tt{rl_completion_append_character} to
+@racket[c].  The value is reset by the readline library, so it must
+be set inside a completion function each time it is called.
+The default is @racket[#\space].  Set it to @racket[#\null] to
+have no character appended to the completion result.
+
+@history[#:added "1.1"]}
+
 @defproc[(readline-newline) void?]{
 
 Sets the cursor to the start of a new line.}

--- a/readline-doc/readline/readline.scrbl
+++ b/readline-doc/readline/readline.scrbl
@@ -276,6 +276,29 @@ be set inside a completion function each time it is called.
 The default is @racket[#\space].  Set it to @racket[#\null] to
 have no character appended to the completion result.
 
+The @tt{rl_completion_append_character} is used by the readline
+library whenever a completion function returns a single option, and it
+is therefore chosen.  The choice will be filled in on the command
+line, and then the @tt{rl_completion_append_character} is
+appended.
+
+As an example, you could set the completion append character to a
+slash when completing the name of a directory, a space when you know
+the user will want to write another argument, or @racket[#\null] to
+avoid appending when a user might want to write something directly
+after the completion, such as punctuation or an extension of a word.
+
+If you want to make a completion function to more easily write the
+names of your favorite characters (and share your excitement about
+them), a use of @racket[set-completion-append-character!] may look
+like this:
+
+@racketblock[
+(define (christmas-character-complete name-str)
+  (set-completion-append-character! #\!)
+  (filter (λ (x) (string-prefix? x name-str))
+          '("Rudolf" "Hermie" "Bumble" "Yukon" "Clarise" "Santa")))]
+
 @history[#:added "1.1"]}
 
 @defproc[(readline-newline) void?]{

--- a/readline-lib/readline/rktrl.rkt
+++ b/readline-lib/readline/rktrl.rkt
@@ -7,6 +7,7 @@
          add-history add-history-bytes
          history-length history-get history-delete
          set-completion-function!
+         set-completion-append-character!
          readline-newline readline-redisplay)
 
 ;; libncurses and/or libtermcap needed on some platforms
@@ -156,6 +157,16 @@
                     [cur (if (string? cur) (string->bytes/utf-8 cur) cur)])
                (malloc (add1 (bytes-length cur)) cur 'raw)))))
     complete))
+
+(define (set-completion-append-character! c)
+  (cond [(char? c)
+         (set-ffi-obj! "rl_completion_append_character"
+                       libreadline
+                       _int
+                       (char->integer c))]
+        [else (raise-argument-error 'set-completion-append-character!
+                                    "char?"
+                                    c)]))
 
 (set-ffi-obj! "rl_readline_name" libreadline _pointer
               (let ([s #"mzscheme"])


### PR DESCRIPTION
This fixes my biggest frustration with custom completion functions.

The check for `char?` could be a contract, but I didn't want to change the requires.  Also, I figure this is close enough on the heels of the last addition that it probably doesn't need a further version bump, but I can add one if it's desired.